### PR TITLE
Remove shared_ptr to DMFile inside DMFilePackFilterResult 

### DIFF
--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
@@ -40,7 +40,7 @@ void ColumnFileBig::calculateStat(const DMContext & dm_context)
     std::tie(valid_rows, valid_bytes) = DMFilePackFilter::loadValidRowsAndBytes(
         dm_context,
         file,
-        /*set_cache_if_miss*/ true,
+        /*set_cache_if_miss*/ false,
         {segment_range});
 }
 

--- a/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
+++ b/dbms/src/Storages/DeltaMerge/ColumnFile/ColumnFileBig.cpp
@@ -37,14 +37,11 @@ ColumnFileBig::ColumnFileBig(const DMContext & dm_context, const DMFilePtr & fil
 
 void ColumnFileBig::calculateStat(const DMContext & dm_context)
 {
-    auto pack_filter = DMFilePackFilter::loadFrom(
+    std::tie(valid_rows, valid_bytes) = DMFilePackFilter::loadValidRowsAndBytes(
         dm_context,
         file,
-        /*set_cache_if_miss*/ false,
-        {segment_range},
-        EMPTY_RS_OPERATOR,
-        {});
-    std::tie(valid_rows, valid_bytes) = pack_filter->validRowsAndBytes();
+        /*set_cache_if_miss*/ true,
+        {segment_range});
 }
 
 void ColumnFileBig::removeData(WriteBatches & wbs) const

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -29,7 +29,7 @@ DMFilePackFilterResultPtr DMFilePackFilter::load()
     Stopwatch watch;
     SCOPE_EXIT({ scan_context->total_rs_pack_filter_check_time_ns += watch.elapsed(); });
     size_t pack_count = dmfile->getPacks();
-    DMFilePackFilterResult result(index_cache, file_provider, read_limiter, scan_context, dmfile);
+    DMFilePackFilterResult result(index_cache, read_limiter, dmfile);
     auto read_all_packs = (rowkey_ranges.size() == 1 && rowkey_ranges[0].all()) || rowkey_ranges.empty();
     if (!read_all_packs)
     {

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.cpp
@@ -17,6 +17,7 @@
 #include <IO/FileProvider/ChecksumReadBufferBuilder.h>
 #include <Storages/DeltaMerge/File/DMFilePackFilter.h>
 #include <Storages/DeltaMerge/Filter/FilterHelper.h>
+#include <Storages/DeltaMerge/Filter/RSOperator.h>
 #include <Storages/DeltaMerge/RowKeyRange.h>
 #include <Storages/DeltaMerge/ScanContext.h>
 
@@ -24,12 +25,34 @@
 namespace DB::DM
 {
 
+std::pair<size_t, size_t> DMFilePackFilter::loadValidRowsAndBytes(
+    const DMContext & dm_context,
+    const DMFilePtr & dmfile,
+    bool set_cache_if_miss,
+    const RowKeyRanges & rowkey_ranges)
+{
+    auto pack_filter = loadFrom(dm_context, dmfile, set_cache_if_miss, rowkey_ranges, EMPTY_RS_OPERATOR, {});
+
+    size_t rows = 0;
+    size_t bytes = 0;
+    const auto & pack_stats = dmfile->getPackStats();
+    for (size_t i = 0; i < pack_stats.size(); ++i)
+    {
+        if (pack_filter->pack_res[i].isUse())
+        {
+            rows += pack_stats[i].rows;
+            bytes += pack_stats[i].bytes;
+        }
+    }
+    return {rows, bytes};
+}
+
 DMFilePackFilterResultPtr DMFilePackFilter::load()
 {
     Stopwatch watch;
     SCOPE_EXIT({ scan_context->total_rs_pack_filter_check_time_ns += watch.elapsed(); });
     size_t pack_count = dmfile->getPacks();
-    DMFilePackFilterResult result(index_cache, read_limiter, dmfile);
+    DMFilePackFilterResult result(index_cache, read_limiter, pack_count);
     auto read_all_packs = (rowkey_ranges.size() == 1 && rowkey_ranges[0].all()) || rowkey_ranges.empty();
     if (!read_all_packs)
     {

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilter.h
@@ -39,6 +39,13 @@ class DMFilePackFilter
     friend class DMFilePackFilterResult;
 
 public:
+    // Get valid rows and bytes after filter invalid packs by rowkey_ranges
+    static std::pair<size_t, size_t> loadValidRowsAndBytes(
+        const DMContext & dm_context,
+        const DMFilePtr & dmfile,
+        bool set_cache_if_miss,
+        const RowKeyRanges & rowkey_ranges);
+
     // Empty `rowkey_ranges` means do not filter by rowkey_ranges
     static DMFilePackFilterResultPtr loadFrom(
         const DMContext & dm_context,

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
@@ -59,7 +59,10 @@ std::tuple<UInt64, UInt64, UInt64, UInt64> DMFilePackFilterResult::countPackRes(
     return {none_count, some_count, all_count, all_null_count};
 }
 
-void DMFilePackFilterResult::tryLoadIndex(ColId col_id) const
+void DMFilePackFilterResult::tryLoadIndex(
+    ColId col_id,
+    const FileProviderPtr & file_provider,
+    const ScanContextPtr & scan_context) const
 {
     if (param.indexes.count(col_id))
         return;

--- a/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFilePackFilterResult.cpp
@@ -23,22 +23,6 @@ UInt64 DMFilePackFilterResult::countUsePack() const
     return std::count_if(pack_res.begin(), pack_res.end(), [](RSResult res) { return res.isUse(); });
 }
 
-std::pair<size_t, size_t> DMFilePackFilterResult::validRowsAndBytes()
-{
-    size_t rows = 0;
-    size_t bytes = 0;
-    const auto & pack_stats = dmfile->getPackStats();
-    for (size_t i = 0; i < pack_stats.size(); ++i)
-    {
-        if (pack_res[i].isUse())
-        {
-            rows += pack_stats[i].rows;
-            bytes += pack_stats[i].bytes;
-        }
-    }
-    return {rows, bytes};
-}
-
 std::tuple<UInt64, UInt64, UInt64, UInt64> DMFilePackFilterResult::countPackRes() const
 {
     UInt64 none_count = 0;
@@ -60,6 +44,7 @@ std::tuple<UInt64, UInt64, UInt64, UInt64> DMFilePackFilterResult::countPackRes(
 }
 
 void DMFilePackFilterResult::tryLoadIndex(
+    const DMFilePtr & dmfile,
     ColId col_id,
     const FileProviderPtr & file_provider,
     const ScanContextPtr & scan_context) const

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -312,7 +312,7 @@ Block DMFileReader::readImpl(const ReadBlockInfo & read_info)
             // If all handle in a pack are in the given range, no not_clean rows, and max version <= max_read_version,
             // we do not need to read handle column.
             if (handle_res[i] == RSResult::All && pack_stats[i].not_clean == 0
-                && pack_filter->getMaxVersion(i) <= max_read_version)
+                && pack_filter->getMaxVersion(i, file_provider, scan_context) <= max_read_version)
             {
                 handle_column_clean_read_packs.push_back(i);
                 version_column_clean_read_packs.push_back(i);
@@ -375,12 +375,12 @@ ColumnPtr DMFileReader::cleanRead(
     {
         if (is_common_handle)
         {
-            StringRef min_handle = pack_filter->getMinStringHandle(range.first);
+            StringRef min_handle = pack_filter->getMinStringHandle(range.first, file_provider, scan_context);
             return cd.type->createColumnConst(rows_count, Field(min_handle.data, min_handle.size));
         }
         else
         {
-            Handle min_handle = pack_filter->getMinHandle(range.first);
+            Handle min_handle = pack_filter->getMinHandle(range.first, file_provider, scan_context);
             return cd.type->createColumnConst(rows_count, Field(min_handle));
         }
     }

--- a/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
+++ b/dbms/src/Storages/DeltaMerge/File/DMFileReader.cpp
@@ -312,7 +312,7 @@ Block DMFileReader::readImpl(const ReadBlockInfo & read_info)
             // If all handle in a pack are in the given range, no not_clean rows, and max version <= max_read_version,
             // we do not need to read handle column.
             if (handle_res[i] == RSResult::All && pack_stats[i].not_clean == 0
-                && pack_filter->getMaxVersion(i, file_provider, scan_context) <= max_read_version)
+                && pack_filter->getMaxVersion(dmfile, i, file_provider, scan_context) <= max_read_version)
             {
                 handle_column_clean_read_packs.push_back(i);
                 version_column_clean_read_packs.push_back(i);
@@ -375,12 +375,12 @@ ColumnPtr DMFileReader::cleanRead(
     {
         if (is_common_handle)
         {
-            StringRef min_handle = pack_filter->getMinStringHandle(range.first, file_provider, scan_context);
+            StringRef min_handle = pack_filter->getMinStringHandle(dmfile, range.first, file_provider, scan_context);
             return cd.type->createColumnConst(rows_count, Field(min_handle.data, min_handle.size));
         }
         else
         {
-            Handle min_handle = pack_filter->getMinHandle(range.first, file_provider, scan_context);
+            Handle min_handle = pack_filter->getMinHandle(dmfile, range.first, file_provider, scan_context);
             return cd.type->createColumnConst(rows_count, Field(min_handle));
         }
     }

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -69,6 +69,8 @@
 #include <ext/scope_guard.h>
 #include <memory>
 
+#include "Storages/DeltaMerge/ScanContext_fwd.h"
+
 
 namespace ProfileEvents
 {
@@ -3129,7 +3131,8 @@ struct Range
 std::pair<std::vector<Range>, std::vector<IdSetPtr>> parseDMFilePackInfo(
     const DMFiles & dmfiles,
     const DMFilePackFilterResults & pack_filter_result,
-    UInt64 start_ts)
+    UInt64 start_ts,
+    const DMContext & dm_context)
 {
     // Packs that all rows compliant with MVCC filter and RowKey filter requirements.
     // For building bitmap filter, we don't need to read these packs,
@@ -3146,6 +3149,8 @@ std::pair<std::vector<Range>, std::vector<IdSetPtr>> parseDMFilePackInfo(
     // The number of rows in the current range.
     size_t rows = 0;
     UInt32 preceded_rows = 0;
+
+    auto file_provider = dm_context.global_context.getFileProvider();
 
     for (size_t i = 0; i < dmfiles.size(); ++i)
     {
@@ -3167,7 +3172,7 @@ std::pair<std::vector<Range>, std::vector<IdSetPtr>> parseDMFilePackInfo(
             }
 
             if (handle_res[pack_id] == RSResult::Some || pack_stat.not_clean > 0
-                || pack_filter->getMaxVersion(pack_id) > start_ts)
+                || pack_filter->getMaxVersion(pack_id, file_provider, dm_context.scan_context) > start_ts)
             {
                 // We need to read this pack to do RowKey or MVCC filter.
                 some_packs_set->insert(pack_id);
@@ -3216,7 +3221,7 @@ BitmapFilterPtr Segment::buildBitmapFilterStableOnly(
         return elapse_ns / 1'000'000.0;
     };
 
-    auto [skipped_ranges, some_packs_sets] = parseDMFilePackInfo(dmfiles, pack_filter_results, start_ts);
+    auto [skipped_ranges, some_packs_sets] = parseDMFilePackInfo(dmfiles, pack_filter_results, start_ts, dm_context);
 
     if (skipped_ranges.size() == 1 && skipped_ranges[0].offset == 0
         && skipped_ranges[0].rows == segment_snap->stable->getDMFilesRows())

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -69,8 +69,6 @@
 #include <ext/scope_guard.h>
 #include <memory>
 
-#include "Storages/DeltaMerge/ScanContext_fwd.h"
-
 
 namespace ProfileEvents
 {
@@ -3172,7 +3170,7 @@ std::pair<std::vector<Range>, std::vector<IdSetPtr>> parseDMFilePackInfo(
             }
 
             if (handle_res[pack_id] == RSResult::Some || pack_stat.not_clean > 0
-                || pack_filter->getMaxVersion(pack_id, file_provider, dm_context.scan_context) > start_ts)
+                || pack_filter->getMaxVersion(dmfile, pack_id, file_provider, dm_context.scan_context) > start_ts)
             {
                 // We need to read this pack to do RowKey or MVCC filter.
                 some_packs_set->insert(pack_id);

--- a/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
+++ b/dbms/src/Storages/DeltaMerge/StableValueSpace.cpp
@@ -49,14 +49,11 @@ void StableValueSpace::setFiles(const DMFiles & files_, const RowKeyRange & rang
     {
         for (const auto & file : files_)
         {
-            auto pack_filter = DMFilePackFilter::loadFrom(
+            auto [file_valid_rows, file_valid_bytes] = DMFilePackFilter::loadValidRowsAndBytes(
                 *dm_context,
                 file,
                 /*set_cache_if_miss*/ true,
-                {range},
-                EMPTY_RS_OPERATOR,
-                {});
-            auto [file_valid_rows, file_valid_bytes] = pack_filter->validRowsAndBytes();
+                {range});
             rows += file_valid_rows;
             bytes += file_valid_bytes;
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?



```commit-message
* Replace `DMFilePackFilterResult::validRowsAndBytes` by `DMFilePackFilter::loadValidRowsAndBytes`
* Remove shared_ptr to DMFile and other useless member from `DMFilePackFilterResult`
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
